### PR TITLE
Lock node version on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # You can specify a version:
 # FROM node:10-slim
-FROM node:slim
+FROM node:20-slim
 
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"="VTEX IO Test Action"


### PR DESCRIPTION
This action started failing on Node 25.x

<img width="1530" height="778" alt="image" src="https://github.com/user-attachments/assets/465668ca-de0c-4547-af2d-a82e256a72aa" />

